### PR TITLE
Filter Redirect URL for Cloned Posts

### DIFF
--- a/class-cr-clone.php
+++ b/class-cr-clone.php
@@ -72,8 +72,13 @@ class CR_Clone {
 		 * @since 0.2
 		 *
 		 * @param string $redirect_url URL string passed to wp_redirect
+		 * @param int    $post_id      ID for newly cloned post.
 		 */
-		$redirect_url = apply_filters( 'CR_Clone_redirect_url', admin_url( "post.php?post={$post_id}&action=edit" ) );
+		$redirect_url = apply_filters(
+			'CR_Clone_redirect_url',
+			admin_url( "post.php?post={$post_id}&action=edit" ),
+			$post_id
+		);
 
 		wp_redirect( esc_url_raw( $redirect_url ) );
 		exit();

--- a/class-cr-clone.php
+++ b/class-cr-clone.php
@@ -64,7 +64,17 @@ class CR_Clone {
 			wp_die( esc_html__( 'There was an error copying this post', 'clone-replace' ) );
 		}
 
-		wp_redirect( admin_url( "post.php?post={$post_id}&action=edit" ) );
+		// Modify individual query args for redirect URL.
+		$admin_redirect_url = add_query_arg(
+			apply_filters( 'CR_Clone_redirect_query_args', [
+				'post'   => $post_id,
+				'action' => 'edit',
+			] ),
+			admin_url( "post.php" )
+		);
+
+		// Change redirect url completely using the filter below.
+		wp_redirect( esc_url( apply_filters( 'CR_Clone_redirect_url', $admin_redirect_url ) ) );
 		exit();
 	}
 

--- a/class-cr-clone.php
+++ b/class-cr-clone.php
@@ -64,17 +64,18 @@ class CR_Clone {
 			wp_die( esc_html__( 'There was an error copying this post', 'clone-replace' ) );
 		}
 
-		// Modify individual query args for redirect URL.
-		$admin_redirect_url = add_query_arg(
-			apply_filters( 'CR_Clone_redirect_query_args', [
-				'post'   => $post_id,
-				'action' => 'edit',
-			] ),
-			admin_url( "post.php" )
-		);
+		/**
+		 * Filter Cloned Post Redirect URL.
+		 *
+		 * Modify the resulting redirect location after cloning a post.
+		 *
+		 * @since 0.2
+		 *
+		 * @param string $redirect_url URL string passed to wp_redirect
+		 */
+		$redirect_url = apply_filters( 'CR_Clone_redirect_url', admin_url( "post.php?post={$post_id}&action=edit" ) );
 
-		// Change redirect url completely using the filter below.
-		wp_redirect( esc_url( apply_filters( 'CR_Clone_redirect_url', $admin_redirect_url ) ) );
+		wp_redirect( esc_url_raw( $redirect_url ) );
 		exit();
 	}
 

--- a/clone-replace.php
+++ b/clone-replace.php
@@ -4,7 +4,7 @@
 	Plugin Name: Clone & Replace
 	Plugin URI: http://www.alleyinteractive.com/
 	Description: Gives you the ability to clone posts, and replace posts. Together, you have a very powerful tool for a fork/merge editing model.
-	Version: 0.1
+	Version: 0.2
 	Author: Matthew Boynes
 	Author URI: http://www.alleyinteractive.com/
 */

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,10 @@ Everything about a post will be replaced except its *Post ID*, *Slug*, *GUID*, *
 
 == Upgrade Notice ==
 
+= 0.2 =
+Adds filter `CR_Clone_redirect_url`, used to change redirect URL after successfully cloning a post.
+
+
 = 0.1 =
 Brand new, nothing to see here.
 


### PR DESCRIPTION
Adds two new filters that allow developers to modify the resulting redirect URL.  This PR bumps the plugin version to `0.2` and adds a note to `readme.txt` about the new filter.

#### `CR_Clone_redirect_url`
> Filters entire URL string. Redirect to somewhere other than `post.php` 